### PR TITLE
Grammar additions

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -155,7 +155,7 @@
   {
     'captures':
       '1':
-        'name': 'keyword.control.media.fontface.css'
+        'name': 'keyword.control.at-rule.media.css'
       '2':
         'name': 'punctuation.definition.keyword.css'
     'match': '^\\s*((@)media\\b)'


### PR DESCRIPTION
The grammar for Less was missing many definitions found in CSS and SCSS. This has always been a problem with the TextMate package this, and the package for Sublime Text, have been derived from. Less deserves to be awesome, therefore my contribution to bring it more in line with CSS and SCSS. Should also help the development of the [one-dark-syntax package](https://github.com/atom/one-dark-syntax/issues/2#issuecomment-64310911) and others since (in my experience at least) the Less grammar is one of the most limited.

For these additions, I tried to preserve and re-use existing definitions in the Less grammar. E.g. `@media` is derived from `@import`. I looked at the CSS and SCSS grammars for ideas and some regexes. 

The improvements:
- `:first-child` highlighting was broken
- lots of punctuation wasn't defined (`:`, `;`, but also `.` and `#` for classes and ids)
- many operator keywords weren't defined (`and` etc. for instance in media queries)
- many modern units weren't defined (e.g. `vh` and `s`)
- there were rules for vendor prefixes but they didn't work, I brought this in line with SCSS and CSS
- `@media`, `@font-face` and `!important` weren't defined
- some missing property names like `src`
- many built-in less functions were missing

Before:
![before1](https://cloud.githubusercontent.com/assets/2543659/5180016/074bedf6-7487-11e4-9fda-38eb8c6b34f5.png)
![before 3](https://cloud.githubusercontent.com/assets/2543659/5180018/0c4808b2-7487-11e4-9e9a-abff8386faaf.png)
![before2](https://cloud.githubusercontent.com/assets/2543659/5180022/13268ce4-7487-11e4-8a1a-b9e9249b863d.png)

After
![after1](https://cloud.githubusercontent.com/assets/2543659/5180036/3c2b2d16-7487-11e4-833c-421710c8e961.png)
![after 3](https://cloud.githubusercontent.com/assets/2543659/5180037/3ef72f0e-7487-11e4-86f0-3227fcaed027.png)
![after2](https://cloud.githubusercontent.com/assets/2543659/5180039/417989ac-7487-11e4-82db-1eef71a3b061.png)
