### PR TITLE
added definitions for media query features

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -191,14 +191,8 @@
     'name': 'support.constant.media.css'
   }
   {
-    'captures':
-      '1':
-        'name': 'support.function.any-method.vendor.css'
-    'match': '(-(?:webkit|moz|khtml|o|icab)-(?:gradient|linear-gradient))'
-  }
-  {
     'match': '\\b(color-stop|from|to)\\b'
-    'name': 'support.function.any-method.webkit.gradient.css'
+    'name': 'support.function.any-method.gradient.css'
   }
   {
     'captures':


### PR DESCRIPTION
Fixes issue #13 

Media types were added from the css grammar.

Added features from http://www.w3.org/TR/css3-mediaqueries/ to the definitions, including min/max prefixes, and separate entries for the color and monochrome features.

Before
![before](https://cloud.githubusercontent.com/assets/2543659/5192424/a724dbb0-74f7-11e4-87e2-89bf5a82405e.png)

After
![after](https://cloud.githubusercontent.com/assets/2543659/5192426/add8ecda-74f7-11e4-8334-96147f531bb3.png)
