### PR TITLE
Fix url function

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -56,12 +56,6 @@
     'match': '((\\.)[_a-zA-Z][a-zA-Z0-9_-]*)'
   }
   {
-    'begin': 'url\\('
-    'contentName': 'variable.parameter.url'
-    'end': '\\)'
-    'name': 'support.function.any-method.builtin.css'
-  }
-  {
     'match': '(#)([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\\b(?!.*?\\{)'
     'name': 'constant.other.rgb-value.css'
   }


### PR DESCRIPTION
Duplicated and wrongly colorized.

Before:
![before](https://cloud.githubusercontent.com/assets/1958425/5328540/4652806c-7d7b-11e4-8299-34023947927f.png)

After:
![after](https://cloud.githubusercontent.com/assets/1958425/5328542/4de44c5c-7d7b-11e4-8fda-92665a561836.png)
