### PR TITLE
tokenize attribute selector end punctuation

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -156,7 +156,7 @@
   {
     'captures':
       '1':
-        'name': 'punctuation.definition.entity.css'
+        'name': 'punctuation.definition.begin.entity.css'
       '2':
         'name': 'entity.other.attribute-name.attribute.css'
       '3':
@@ -169,6 +169,8 @@
         'name': 'punctuation.definition.string.begin.css'
       '7':
         'name': 'punctuation.definition.string.end.css'
+      '8':
+        'name': 'punctuation.definition.end.entity.css'
     'match': '(?i)(\\[)\\s*(-?[_a-z\\\\[[:^ascii:]]][_a-z0-9\\-\\\\[[:^ascii:]]]*)(?:\\s*([~|^$*]?=)\\s*(?:(-?[_a-z\\\\[[:^ascii:]]][_a-z0-9\\-\\\\[[:^ascii:]]]*)|((?>([\'"])(?:[^\\\\]|\\\\.)*?(\\6)))))?\\s*(\\])'
     'name': 'meta.attribute-selector.css'
   }


### PR DESCRIPTION
While the existing regex matches the `]` at the end of an attribute selector, it isn't assigned a name, which leaves it dangling. Also, wrapping punctuation is usually assigned "begin" and "end" names.

before:
![before](https://cloud.githubusercontent.com/assets/2543659/5643893/e0b718fc-965d-11e4-8531-1befb281934b.png)

after:
![after](https://cloud.githubusercontent.com/assets/2543659/5643892/e0971430-965d-11e4-84c0-82bcd616c968.png)

Specs for this package are incomplete so I didn't add any for this change.