### PR TITLE
Adding .rc, themerc and gtkrc filetypes/names

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -1,8 +1,13 @@
 'name': 'Less'
 'scopeName': 'source.css.less'
+'fileNames': [
+  'gtkrc'
+  'themerc'
+]
 'fileTypes': [
   'less'
   'less.erb'
+  'rc'
 ]
 'patterns': [
   {

--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -1,13 +1,12 @@
 'name': 'Less'
 'scopeName': 'source.css.less'
-'fileNames': [
-  'gtkrc'
-  'themerc'
-]
 'fileTypes': [
   'less'
   'less.erb'
   'rc'
+  'gtkrc'
+  'gtkrc-2.0'
+  'themerc'
 ]
 'patterns': [
   {


### PR DESCRIPTION
GTK/XFWM themes use files in Less format with themerc and gtkrc file names and .rc file extensions. 