### PR TITLE
Fix issue with highlighting custom tag when attribute selector presented

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -289,7 +289,7 @@
     'name': 'keyword.control.html.svg.elements'
   }
   {
-    'match': '(?<!:)\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:+(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-child()|nth-last-child()|nth-of-type()|nth-last-of-type()|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid|shadow)(\\([0-9A-Za-z]*\\))?)'
+    'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)'
     'name': 'keyword.control.html.custom.elements'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -203,6 +203,31 @@ describe "less grammar", ->
     expect(lines[1][0]).toEqual value: 'another-one', scopes: ['source.css.less', 'keyword.control.html.custom.elements']
     expect(lines[1][10]).toEqual value: '}', scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.section.property-list.end.css']
 
+  it 'parses custom tag with pseudo classes', ->
+    {tokens} = grammar.tokenizeLine("very-very-custom:hover::after { color: inherit }")
+    expect(tokens[0]).toEqual value: 'very-very-custom', scopes: ['source.css.less', 'keyword.control.html.custom.elements']
+    expect(tokens[1]).toEqual value: ":", scopes: ['source.css.less', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+    expect(tokens[2]).toEqual value: "hover", scopes: ['source.css.less', 'entity.other.attribute-name.pseudo-class.css']
+    expect(tokens[3]).toEqual value: "::", scopes: ['source.css.less', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+    expect(tokens[4]).toEqual value: "after", scopes: ['source.css.less', 'entity.other.attribute-name.pseudo-element.css']
+
+  it 'parses custom tag with pseudo classes containings dash symbol', ->
+    {tokens} = grammar.tokenizeLine("very-very-custom:first-child { color: inherit }")
+    expect(tokens[0]).toEqual value: 'very-very-custom', scopes: ['source.css.less', 'keyword.control.html.custom.elements']
+    expect(tokens[1]).toEqual value: ":", scopes: ['source.css.less', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+    expect(tokens[2]).toEqual value: "first-child", scopes: ['source.css.less', 'entity.other.attribute-name.pseudo-class.css']
+
+  it 'parses custom tag with attributes', ->
+    {tokens} = grammar.tokenizeLine("very-very-custom[name=\"custom\"] { color: inherit }")
+    expect(tokens[0]).toEqual value: 'very-very-custom', scopes: ['source.css.less', 'keyword.control.html.custom.elements']
+    expect(tokens[1]).toEqual value: "[", scopes: ['source.css.less', 'meta.attribute-selector.css', 'punctuation.definition.begin.entity.css']
+    expect(tokens[2]).toEqual value: "name", scopes: ['source.css.less', 'meta.attribute-selector.css', 'entity.other.attribute-name.attribute.css']
+    expect(tokens[3]).toEqual value: "=", scopes: ['source.css.less', 'meta.attribute-selector.css', 'punctuation.separator.operator.css']
+    expect(tokens[4]).toEqual value: "\"", scopes: ['source.css.less', 'meta.attribute-selector.css', 'string.quoted.double.attribute-value.css', 'punctuation.definition.string.begin.css']
+    expect(tokens[5]).toEqual value: "custom", scopes: ['source.css.less', 'meta.attribute-selector.css', 'string.quoted.double.attribute-value.css']
+    expect(tokens[6]).toEqual value: "\"", scopes: ['source.css.less', 'meta.attribute-selector.css', 'string.quoted.double.attribute-value.css', 'punctuation.definition.string.end.css']
+    expect(tokens[7]).toEqual value: "]", scopes: ['source.css.less', 'meta.attribute-selector.css', 'punctuation.definition.end.entity.css']
+
   it "parses variables", ->
     {tokens} = grammar.tokenizeLine(".foo { border: @bar; }")
     expect(tokens).toHaveLength 12


### PR DESCRIPTION
Fix issue with highlighting custom tag with attribute selector

<img width="260" alt="screen shot 2016-08-17 at 4 42 12 pm" src="https://cloud.githubusercontent.com/assets/2151610/17757356/efa1eb14-649a-11e6-990b-835568d9b3e1.png">

PS. Added tests to cover custom tag highlighting