### PR TITLE
Support css variables

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -228,7 +228,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.variable.less'
-    'match': '@[a-zA-Z0-9_-][\\w-]*(?=\\s*)'
+    'match': '(?:@|\\-\\-)[a-zA-Z0-9_-][\\w-]*(?=\\s*)'
     'name': 'variable.other.less'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -218,6 +218,23 @@ describe "less grammar", ->
     expect(tokens[10]).toEqual value: " ", scopes: ['source.css.less', 'meta.property-list.css']
     expect(tokens[11]).toEqual value: "}", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
 
+  it "parses css variables", ->
+    {tokens} = grammar.tokenizeLine(".foo { --spacing-unit: 6px; }")
+    expect(tokens).toHaveLength 13
+    expect(tokens[0]).toEqual value: ".", scopes: ['source.css.less', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
+    expect(tokens[1]).toEqual value: "foo", scopes: ['source.css.less', 'entity.other.attribute-name.class.css']
+    expect(tokens[2]).toEqual value: " ", scopes: ['source.css.less']
+    expect(tokens[3]).toEqual value: "{", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+    expect(tokens[4]).toEqual value: " ", scopes: ['source.css.less', 'meta.property-list.css']
+    expect(tokens[5]).toEqual value: "--spacing-unit", scopes: ['source.css.less', 'meta.property-list.css', 'variable.other.less']
+    expect(tokens[6]).toEqual value: ":", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+    expect(tokens[7]).toEqual value: " ", scopes: ['source.css.less', 'meta.property-list.css']
+    expect(tokens[8]).toEqual value: "6", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
+    expect(tokens[9]).toEqual value: "px", scopes: [ 'source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'keyword.other.unit.css' ]
+    expect(tokens[10]).toEqual value: ";", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+    expect(tokens[11]).toEqual value: " ", scopes: ['source.css.less', 'meta.property-list.css']
+    expect(tokens[12]).toEqual value: "}", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
   it 'parses variable interpolation in selectors', ->
     {tokens} = grammar.tokenizeLine '.@{selector} { color: #0ee; }'
     expect(tokens[0]).toEqual value: '.', scopes: ['source.css.less', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']


### PR DESCRIPTION
### Description of the Change

The patch adds support for css variables (properties starting with --) and gives them the same scope as less variables (`variable.other.less`).
```css
:root {
    --spacing-unit: 6px;
    --cell-padding: (4 * var(--spacing-unit));
}
```

Test has been added too.
The change is in use in VSCode for a while now, without any known issues.

### Alternate Designs

A different scope could be considered, such as `variable.css.scss`, matching the scope that the language-css grammar uses.

### Benefits

Correct coloring of css variables in LESS.