### PR TITLE
Link keyword-lists to CSS grammar

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -164,7 +164,7 @@
         'include': '#brace_round'
       }
       {
-        'include': '#commas'
+        'include': 'source.css#commas'
       }
       {
         'include': '#strings'
@@ -190,8 +190,7 @@
     'name': 'meta.at-rule.media.css'
   }
   {
-    'match': '\\b(width|scan|resolution|orientation|monochrome|min-width|min-resolution|min-monochrome|min-height|min-device-width|min-device-height|min-device-aspect-ratio|min-color-index|min-color|min-aspect-ratio|max-width|max-resolution|max-monochrome|max-height|max-device-width|max-device-height|max-device-aspect-ratio|max-color-index|max-color|max-aspect-ratio|height|grid|device-width|device-height|device-aspect-ratio|color-index|color|aspect-ratio)\\b'
-    'name': 'support.type.property-name.media-feature.media.css'
+    'include': 'source.css#media-features'
   }
   {
     'match': '\\b(tv|tty|screen|projection|print|handheld|embossed|braille|aural|all)\\b'
@@ -246,19 +245,22 @@
     'name': 'meta.property-list.css'
     'patterns': [
       {
-        'include': '#pseudo_elements'
+        'include': 'source.css#pseudo-elements'
       }
       {
-        'include': '#pseudo_classes'
+        'include': 'source.css#pseudo-classes'
+      }
+      {
+        'include': 'source.css#tag-names'
+      }
+      {
+        'include': 'source.css#commas'
       }
       {
         'include': '#variable_interpolation'
       }
       {
-        'include': '#property_names'
-      }
-      {
-        'include': '#property_names_svg'
+        'include': 'source.css#property-names'
       }
       {
         'include': '#property_values'
@@ -281,59 +283,25 @@
     'name': 'keyword.control.logical.operator.less'
   }
   {
-    'match': '''(?x)
-      (?<![\\w-])
-      (a|abbr|address|area|article|aside|audio
-      |b|base|bdi|bdo|blockquote|body|br|button
-      |canvas|caption|cite|code|col|colgroup
-      |data|datalist|dd|del|details|dfn|dialog|div|dl|dt
-      |em|embed|fieldset|figure|figcaption|footer|form
-      |h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins
-      |kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter
-      |nav|noscript|object|ol|optgroup|option|output
-      |p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby
-      |s|samp|script|section|select|small|source|span|strong|style|sub|summary|sup|svg
-      |table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track
-      |u|ul|var|video|wbr)
-      (?![\\w-])
-    '''
-    'name': 'entity.name.tag.css'
-  }
-  {
-    'match': '''(?x)
-      (?<![\\w-])
-      (vkern|view|use|tspan|tref|textPath|text|symbol|switch|stop|set
-      |rect|radialGradient|polyline|polygon|pattern|path
-      |mpath|missing-glyph|metadata|mask|marker|linearGradient|line
-      |image|hkern|glyphRef|glyph|g
-      |foreignObject|font(-face(-uri|-src|-name|-format)?)?|filter
-      |fe(Turbulence|Tile|SpotLight|SpecularLighting|PointLight|Offset
-        |Morphology|MergeNode|Merge|Image|GaussianBlur|Func[RGBA]
-        |Flood|DistantLight|DisplacementMap|DiffuseLighting
-        |ConvolveMatrix|Composite|ComponentTransfer|ColorMatrix|Blend)
-      |ellipse|desc|defs|cursor|color-profile|clipPath|circle
-      |animate(Transform|Motion|Color)?|altGlyph(Item|Def)?)
-      (?![\\w-])
-    '''
-    'name': 'entity.name.tag.svg.css'
+    'include': 'source.css#tag-names'
   }
   {
     'match': '(?<![\\w-])[a-z][\\w&&[^A-Z]]*+-[\\w-&&[^A-Z]]+'
     'name': 'entity.name.tag.custom.css'
   }
   {
-    'include': '#pseudo_elements'
+    'include': 'source.css#pseudo-elements'
   }
   {
-    'include': '#pseudo_classes'
+    'include': 'source.css#pseudo-classes'
   }
   {
+    # Match empty braces to give proper ↩ action
     'captures':
       '1':
         'name': 'punctuation.section.property-list.begin.css'
       '2':
         'name': 'punctuation.section.property-list.end.css'
-    'comment': 'Match empty braces to give proper ↩ action'
     'match': '(\\{)(\\})'
     'name': 'meta.brace.curly.css'
   }
@@ -375,22 +343,19 @@
     'name': 'support.function.unit-checking.less'
   }
   {
-    'include': '#font_names'
+    'include': 'source.css#property-keywords'
   }
   {
-    'include': '#commas'
+    'include': 'source.css#color-keywords'
   }
   {
-    'include': '#color_names'
+    'include': 'source.css#commas'
   }
   {
     'include': '#less_builtin_functions'
   }
   {
-    'include': '#css_builtin_functions'
-  }
-  {
-    'include': '#gradient_builtin_functions'
+    'include': 'source.css#functions'
   }
 ]
 'repository':
@@ -440,22 +405,9 @@
         ]
       }
     ]
-  'commas':
-    'match': ','
-    'name': 'punctuation.separator.list.comma.css'
   'brace_round':
     'match': '\\(|\\)'
     'name': 'meta.brace.round.css'
-  'property_names':
-    'captures':
-      '1':
-        'name': 'support.type.property-name.css'
-    'match': '(?<![-a-z])(-webkit-[-A-Za-z]+|-moz-[-A-Za-z]+|-o-[-A-Za-z]+|-ms-[-A-Za-z]+|-khtml-[-A-Za-z]+|zoom|z-index|y|x|wrap|word-wrap|word-spacing|word-break|word|width|widows|white-space-collapse|white-space|white|weight|volume|voice-volume|voice-stress|voice-rate|voice-pitch-range|voice-pitch|voice-family|voice-duration|voice-balance|voice|visibility|vertical-align|variant|user-select|up|unicode-bidi|unicode-range|unicode|trim|transition-timing-function|transition-property|transition-duration|transition-delay|transition|transform|touch-action|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|text-wrap|text-transform|text-shadow|text-replace|text-rendering|text-overflow|text-outline|text-justify|text-indent|text-height|text-emphasis|text-decoration|text-align-last|text-align|text|target-position|target-new|target-name|target|table-layout|tab-size|style-type|style-position|style-image|style|string-set|stretch|stress|stacking-strategy|stacking-shift|stacking-ruby|stacking|src|speed|speech-rate|speech|speak-punctuation|speak-numeral|speak-header|speak|span|spacing|space-collapse|space|sizing|size-adjust|size|shadow|respond-to|rule-width|rule-style|rule-color|rule|ruby-span|ruby-position|ruby-overhang|ruby-align|ruby|rows|rotation-point|rotation|role|right-width|right-style|right-color|right|richness|rest-before|rest-after|rest|resource|resize|reset|replace|repeat|rendering-intent|rate|radius|quotes|punctuation-trim|punctuation|property|profile|presentation-level|presentation|position|pointer-events|point|play-state|play-during|play-count|pitch-range|pitch|phonemes|pause-before|pause-after|pause|page-policy|page-break-inside|page-break-before|page-break-after|page|padding-top|padding-right|padding-left|padding-bottom|padding|pack|overhang|overflow-y|overflow-x|overflow-style|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|origin|orientation|orient|ordinal-group|order|opacity|offset|numeral|new|nav-up|nav-right|nav-left|nav-index|nav-down|nav|name|move-to|model|mix-blend-mode|min-width|min-height|min|max-width|max-height|max|marquee-style|marquee-speed|marquee-play-count|marquee-direction|marquee|marks|mark-before|mark-after|mark|margin-top|margin-right|margin-left|margin-bottom|margin|mask-image|list-style-type|list-style-position|list-style-image|list-style|list|lines|line-stacking-strategy|line-stacking-shift|line-stacking-ruby|line-stacking|line-height|line-break|level|letter-spacing|length|left-width|left-style|left-color|left|label|justify-content|justify|iteration-count|inline-box-align|initial-value|initial-size|initial-before-align|initial-before-adjust|initial-after-align|initial-after-adjust|index|indent|increment|image-resolution|image-orientation|image|icon|hyphens|hyphenate-resource|hyphenate-lines|hyphenate-character|hyphenate-before|hyphenate-after|hyphenate|height|header|hanging-punctuation|grid-rows|grid-columns|grid|gap|font-kerning|font-language-override|font-weight|font-variant-caps|font-variant|font-style|font-synthesis|font-stretch|font-size-adjust|font-size|font-family|font|float-offset|float|flex-wrap|flex-shrink|flex-grow|flex-group|flex-flow|flex-direction|flex-basis|flex|fit-position|fit|fill|filter|family|empty-cells|emphasis|elevation|duration|drop-initial-value|drop-initial-size|drop-initial-before-align|drop-initial-before-adjust|drop-initial-after-align|drop-initial-after-adjust|drop|down|dominant-baseline|display-role|display-model|display|direction|delay|decoration-break|decoration|cursor|cue-before|cue-after|cue|crop|counter-reset|counter-increment|counter|count|content|columns|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|column-break-before|column-break-after|column|color-profile|color|collapse|clip|clear|character|caption-side|break-inside|break-before|break-after|break|box-sizing|box-shadow|box-pack|box-orient|box-ordinal-group|box-lines|box-flex-group|box-flex|box-direction|box-decoration-break|box-align|box|bottom-width|bottom-style|bottom-right-radius|bottom-left-radius|bottom-color|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-length|border-left-width|border-left-style|border-left-color|border-left|border-image|border-color|border-collapse|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|bookmark-target|bookmark-level|bookmark-label|bookmark|binding|bidi|before|baseline-shift|baseline|balance|background-blend-mode|background-size|background-repeat|background-position|background-origin|background-image|background-color|background-clip|background-break|background-attachment|background|azimuth|attachment|appearance|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-duration|animation-direction|animation-delay|animation-fill-mode|animation|alignment-baseline|alignment-adjust|alignment|align-self|align-last|align-items|align-content|align|after|adjust|will-change)(?=\\s*:?(.*\\\()|(?!.*(?<!@){))\\b'
-  'property_names_svg':
-    'captures':
-      '1':
-        'name': 'support.type.property-name.svg.css'
-    'match': '(?<![-a-z])(writing-mode|text-anchor|stroke-width|stroke-opacity|stroke-miterlimit|stroke-linejoin|stroke-linecap|stroke-dashoffset|stroke-dasharray|stroke|stop-opacity|stop-color|shape-rendering|marker-start|marker-mid|marker-end|lighting-color|kerning|image-rendering|glyph-orientation-vertical|glyph-orientation-horizontal|flood-opacity|flood-color|fill-rule|fill-opacity|fill|enable-background|color-rendering|color-interpolation-filters|color-interpolation|clip-rule|clip-path)(?=\\s*:)'
   'property_values':
     'begin': '(?<!&)(:)\\s*(?!(\\s*{))(?!.*(?<!@){)'
     'beginCaptures':
@@ -467,14 +419,6 @@
         'name': 'punctuation.terminator.rule.css'
     'contentName': 'meta.property-value.css'
     'patterns': [
-      {
-        'match': '\\b(wrap-reverse|wrap|whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|unicase|underline|ultra-expanded|ultra-condensed|transparent|transform|top|titling-caps|thin|thick|text-top|text-bottom|text|tb-rl|table-row-group|table-row|table-header-group|table-footer-group|table-column-group|table-column|table-cell|table|sw-resize|super|strict|stretch|step-start|step-end|static|square|space-between|space-around|space|solid|soft-light|small-caps|separate|semi-expanded|semi-condensed|se-resize|scroll|screen|saturation|s-resize|running|rtl|row-reverse|row-resize|row|round|right|ridge|reverse|repeat-y|repeat-x|repeat|relative|progressive|progress|pre-wrap|pre-line|pre|pointer|petite-caps|paused|pan-x|pan-left|pan-right|pan-y|pan-up|pan-down|padding-box|overline|overlay|outside|outset|optimizeSpeed|optimizeLegibility|opacity|oblique|nw-resize|nowrap|not-allowed|normal|none|no-repeat|no-drop|newspaper|ne-resize|n-resize|multiply|move|middle|medium|max-height|manipulation|main-size|luminosity|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|local|list-item|linear(?!-)|line-through|line-edge|line|lighter|lighten|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline-block|inline|inherit|infinite|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|hue|horizontal|hidden|help|hard-light|hand|groove|geometricPrecision|forwards|flex-start|flex-end|flex|fixed|extra-expanded|extra-condensed|expanded|exclusion|ellipsis|ease-out|ease-in-out|ease-in|ease|e-resize|double|dotted|distribute-space|distribute-letter|distribute-all-lines|distribute|disc|disabled|difference|default|decimal|dashed|darken|currentColor|crosshair|cover|content-box|contain|condensed|column-reverse|column|color-dodge|color-burn|color|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|border-box|bolder|bold|block|bidi-override|below|baseline|balance|backwards|auto|antialiased|always|alternate-reverse|alternate|all-small-caps|all-scroll|all-petite-caps|all|absolute)\\b'
-        'name': 'support.constant.property-value.css'
-      }
-      {
-        'match': '\\b(start|sRGB|square|round|optimizeSpeed|optimizeQuality|nonzero|miter|middle|linearRGB|geometricPrecision |evenodd |end |crispEdges|butt|bevel)\\b'
-        'name': 'support.constant.property-value.svg.css'
-      }
       {
         'begin': 'url(\\()'
         'beginCaptures':
@@ -496,48 +440,25 @@
         ]
       }
       {
-        'include': '#font_names'
+        'include': 'source.css#property-keywords'
       }
       {
-        'include': '#color_names'
+        'include': 'source.css#color-keywords'
+      }
+      {
+        'include': 'source.css#commas'
       }
       {
         'include': '#less_builtin_functions'
       }
       {
-        'include': '#css_builtin_functions'
-      }
-      {
-        'include': '#gradient_builtin_functions'
+        'include': 'source.css#functions'
       }
       {
         'include': '$self'
       }
     ]
-  'pseudo_elements':
-    'captures':
-      '1':
-        'name': 'punctuation.definition.entity.css'
-    'match': '(:|::)(after|before|first-letter|first-line|selection|shadow)'
-    'name': 'entity.other.attribute-name.pseudo-element.css'
-  'pseudo_classes':
-    'captures':
-      '1':
-        'name': 'punctuation.definition.entity.css'
-    'match': '(:)(active|checked|default|dir|disabled|empty|enabled|extend|first-child|first-of-type|first|fullscreen|focus|hover|indeterminate|in-range|invalid|lang|last-child|last-of-type|left|link|not|nth-child|nth-last-child|nth-last-of-type|nth-of-type|only-child|only-of-type|optional|out-of-range|read-only|read-write|required|right|root|scope|shadow|target|valid|visited)(?!\\s*;)'
-    'name': 'entity.other.attribute-name.pseudo-class.css'
-  'font_names':
-    'match': '(\\b(?i:arial|century|comic|courier|cursive|fantasy|futura|garamond|georgia|helvetica|impact|lucida|monospace|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif)\\b)'
-    'name': 'support.constant.font-name.css'
-  'color_names':
-    'match': '\\b(yellowgreen|yellow|whitesmoke|white|wheat|violet|turquoise|tomato|thistle|teal|tan|steelblue|springgreen|snow|slategrey|slategray|slateblue|skyblue|silver|sienna|seashell|seagreen|sandybrown|salmon|saddlebrown|royalblue|rosybrown|red|rebeccapurple|purple|powderblue|plum|pink|peru|peachpuff|papayawhip|palevioletred|paleturquoise|palegreen|palegoldenrod|orchid|orangered|orange|olivedrab|olive|oldlace|navy|navajowhite|moccasin|mistyrose|mintcream|midnightblue|mediumvioletred|mediumturquoise|mediumspringgreen|mediumslateblue|mediumseagreen|mediumpurple|mediumorchid|mediumblue|mediumaquamarine|maroon|linen|limegreen|lime|lightyellow|lightsteelblue|lightslategrey|lightslategray|lightskyblue|lightseagreen|lightsalmon|lightpink|lightgrey|lightgreen|lightgray|lightgoldenrodyellow|lightcyan|lightcoral|lightblue|lemonchiffon|lawngreen|lavenderblush|lavender|khaki|ivory|indigo|indianred|hotpink|honeydew|grey|greenyellow|green|gray|goldenrod|gold|ghostwhite|gainsboro|fuchsia|forestgreen|floralwhite|firebrick|dodgerblue|dimgrey|dimgray|deepskyblue|deeppink|darkviolet|darkturquoise|darkslategrey|darkslategray|darkslateblue|darkseagreen|darksalmon|darkred|darkorchid|darkorange|darkolivegreen|darkmagenta|darkkhaki|darkgrey|darkgreen|darkgray|darkgoldenrod|darkcyan|darkblue|crimson|cornsilk|cornflowerblue|coral|chocolate|chartreuse|cadetblue|burlywood|brown|blueviolet|blue|blanchedalmond|black|bisque|beige|azure|aquamarine|aqua|antiquewhite|aliceblue)\\b'
-    'name': 'support.constant.color.w3c-standard-color-name.css'
   'less_builtin_functions':
     'match': '\\b(abs|acos|alpha|argb|asin|atan|average|blue|calc|ceil|color|contrast|convert|convert|cos|darken|data-uri|desaturate|difference|e|escape|exclusion|extract|fade|fadein|fadeout|floor|format|green|greyscale|hardlight|hsl|hsla|hsv|hsva|hsvhue|hsvsaturation|hsvvalue|hue|length|lighten|lightness|luma|max|min|mix|mod|multiply|negation|overlay|percentage|pi|pow|red|replace|round|saturate|saturation|screen|sin|softlight|spin|sqrt|tan|unit)\\b'
     'name': 'support.function.any-method.builtin.less'
-  'css_builtin_functions':
-    'match': '\\b(url|translate3d|translate[XYZ]|translate|skew[XY]|skew|scale[XYZ]|scale|rotate3d|rotate[XYZ]|rotate|rgba|rgb|repeating-radial-gradient|repeating-linear-gradient|rect|radial-gradient|matrix3d|matrix|linear-gradient|hsla|hsl|drop-shadow|cubic-bezier|blur)\\b'
-    'name': 'support.function.any-method.builtin.css'
-  'gradient_builtin_functions':
-    'match': '\\b(color-stop|from|to)\\b'
-    'name': 'support.function.any-method.gradient.css'
+  

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -3,6 +3,9 @@ describe "less grammar", ->
 
   beforeEach ->
     waitsForPromise ->
+      atom.packages.activatePackage("language-css")
+
+    waitsForPromise ->
       atom.packages.activatePackage("language-less")
 
     runs ->
@@ -28,8 +31,8 @@ describe "less grammar", ->
 
   it 'parses color names', ->
     {tokens} = grammar.tokenizeLine '.foo { color: rebeccapurple; background: whitesmoke; }'
-    expect(tokens[8]).toEqual value: "rebeccapurple", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.color.w3c-standard-color-name.css']
-    expect(tokens[14]).toEqual value: "whitesmoke", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.color.w3c-standard-color-name.css']
+    expect(tokens[8]).toEqual value: "rebeccapurple", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.color.w3c-extended-color-name.css']
+    expect(tokens[14]).toEqual value: "whitesmoke", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.color.w3c-extended-color-name.css']
 
   it "parses property names", ->
     {tokens} = grammar.tokenizeLine("{display: none;}")
@@ -73,13 +76,13 @@ describe "less grammar", ->
     {tokens} = grammar.tokenizeLine('@media (min-width: 100px) {}')
     expect(tokens[0]).toEqual value: "@", scopes: ['source.css.less', 'meta.at-rule.media.css', 'keyword.control.at-rule.media.css', 'punctuation.definition.keyword.css']
     expect(tokens[1]).toEqual value: "media", scopes: ['source.css.less', 'meta.at-rule.media.css', 'keyword.control.at-rule.media.css']
-    expect(tokens[4]).toEqual value: "min-width", scopes: ['source.css.less', 'support.type.property-name.media-feature.media.css']
+    expect(tokens[4]).toEqual value: "min-width", scopes: ['source.css.less', 'support.type.property-name.media.css']
     expect(tokens[7]).toEqual value: "100", scopes: ['source.css.less', 'constant.numeric.css']
     expect(tokens[8]).toEqual value: "px", scopes: ['source.css.less', 'keyword.other.unit.css']
 
   it "parses @media orientation", ->
     {tokens} = grammar.tokenizeLine('@media (orientation: portrait){}')
-    expect(tokens[4]).toEqual value: "orientation", scopes: ['source.css.less', 'support.type.property-name.media-feature.media.css']
+    expect(tokens[4]).toEqual value: "orientation", scopes: ['source.css.less', 'support.type.property-name.media.css']
     expect(tokens[7]).toEqual value: "portrait", scopes: ['source.css.less', 'support.constant.property-value.media-property.media.css']
 
   it "parses parent selector", ->
@@ -291,12 +294,12 @@ describe "less grammar", ->
     expect(tokens[8]).toEqual value: "1", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
     expect(tokens[9]).toEqual value: "px", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'keyword.other.unit.css']
     expect(tokens[11]).toEqual value: "solid", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
-    expect(tokens[13]).toEqual value: "rgba", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.css']
-    expect(tokens[14]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.brace.round.css']
-    expect(tokens[15]).toEqual value: "0", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
-    expect(tokens[16]).toEqual value: ",", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.separator.list.comma.css']
-    expect(tokens[17]).toEqual value: "0", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
-    expect(tokens[18]).toEqual value: ",", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.separator.list.comma.css']
+    expect(tokens[13]).toEqual value: "rgba", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.color.css', 'support.function.misc.css']
+    expect(tokens[14]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.color.css', 'punctuation.section.function.begin.bracket.round.css']
+    expect(tokens[15]).toEqual value: "0", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.color.css', 'constant.numeric.css']
+    expect(tokens[16]).toEqual value: ",", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.color.css', 'punctuation.separator.list.comma.css']
+    expect(tokens[17]).toEqual value: "0", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.color.css', 'constant.numeric.css']
+    expect(tokens[18]).toEqual value: ",", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.color.css', 'punctuation.separator.list.comma.css']
     expect(tokens[21]).toEqual value: ";", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.terminator.rule.css']
 
   it 'parses linear-gradient', ->
@@ -304,16 +307,16 @@ describe "less grammar", ->
     expect(tokens[5]).toEqual value: "background", scopes: ['source.css.less', 'meta.property-list.css', 'support.type.property-name.css']
     expect(tokens[6]).toEqual value: ":", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.separator.key-value.css']
     expect(tokens[7]).toEqual value: " ", scopes: ['source.css.less', 'meta.property-list.css']
-    expect(tokens[8]).toEqual value: "linear-gradient", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.css']
-    expect(tokens[9]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.brace.round.css']
+    expect(tokens[8]).toEqual value: "linear-gradient", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.gradient.css', 'support.function.gradient.css']
+    expect(tokens[9]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.gradient.css', 'punctuation.section.function.begin.bracket.round.css']
 
   it 'parses transform functions', ->
     {tokens} = grammar.tokenizeLine '.foo { transform: scaleY(1); }'
     expect(tokens[5]).toEqual value: "transform", scopes: ['source.css.less', 'meta.property-list.css', 'support.type.property-name.css']
     expect(tokens[6]).toEqual value: ":", scopes: ['source.css.less', 'meta.property-list.css', 'punctuation.separator.key-value.css']
     expect(tokens[7]).toEqual value: " ", scopes: ['source.css.less', 'meta.property-list.css']
-    expect(tokens[8]).toEqual value: "scaleY", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.css']
-    expect(tokens[9]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'meta.brace.round.css']
+    expect(tokens[8]).toEqual value: "scaleY", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.transform.css']
+    expect(tokens[9]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.section.function.begin.bracket.round.css']
 
   it 'parses blend modes', ->
     {tokens} = grammar.tokenizeLine '.foo { background-blend-mode: color-dodge; }'


### PR DESCRIPTION
This PR connects the Less grammar's keyword dictionaries to those defined by `language-css`, so updating the lists will affect both grammars at once.

**Note:** I had to make a [small tweak](https://github.com/atom/language-css/pull/105) to the CSS grammar in order to get tests passing for Less. See atom/language-css#105.

/cc @50Wliu 