### PR TITLE
Stop matching URLs at first closing parenthesis

### DIFF
--- a/grammars/less.cson
+++ b/grammars/less.cson
@@ -429,7 +429,7 @@
             'include': '#strings'
           }
           {
-            'match': '(\\b|\\.{0,2}/).*\\b'
+            'match': '(\\b|\\.{0,2}/)[^)]*\\b'
             'name': 'string.url.css'
           }
         ]

--- a/spec/less-spec.coffee
+++ b/spec/less-spec.coffee
@@ -338,6 +338,14 @@ describe "Less grammar", ->
     expect(tokens[9]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.url.css', 'meta.brace.round.css']
     expect(tokens[10]).toEqual value: "../path/to/image.png", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.url.css', 'string.url.css']
 
+  it 'parses non-quoted urls followed by a format', ->
+    {tokens} = grammar.tokenizeLine '@font-face { src: url(http://example.com/font.woff) format("woff"); }'
+    expect(tokens[8]).toEqual value: 'url', scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.url.css']
+    expect(tokens[9]).toEqual value: "(", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.url.css', 'meta.brace.round.css']
+    expect(tokens[10]).toEqual value: "http://example.com/font.woff", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.url.css', 'string.url.css']
+    expect(tokens[11]).toEqual value: ")", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.url.css', 'meta.brace.round.css']
+    expect(tokens[13]).toEqual value: "format", scopes: ['source.css.less', 'meta.property-list.css', 'meta.property-value.css', 'support.function.any-method.builtin.less']
+
   it 'parses the "true" value', ->
     {tokens} = grammar.tokenizeLine '@var: true;'
     expect(tokens[4]).toEqual value: "true", scopes: ['source.css.less', 'constant.language.boolean.less']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Don't be overeager - stop matching URL strings at the first closing parenthesis.  Fixes the case when there's multiple closing parentheses on the same line, such as one to close the `url` function and another to close a `format` function.

### Alternate Designs

Changing the pattern to use a `match` instead of a begin/end pair.  Decided to keep the change minimal.

### Benefits

No more buggy highlighting when specifying a format after a URL.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #51, supersedes and closes #54