### PR TITLE
Recognize hyphens as part of words for autocomplete, but not cursor movement

### DIFF
--- a/settings/language-less.cson
+++ b/settings/language-less.cson
@@ -1,6 +1,5 @@
 ".source.css.less":
   editor:
-    nonWordCharacters: '/\\()"\':,.;<>~!#$%^&*|+=[]{}`?…'
     commentStart: "// "
   autocomplete:
     symbols:

--- a/settings/language-less.cson
+++ b/settings/language-less.cson
@@ -2,6 +2,7 @@
   editor:
     commentStart: "// "
   autocomplete:
+    extraWordCharacters: '-'
     symbols:
       variable:
         selector: ".variable"


### PR DESCRIPTION
🍐 'd with @nathansobo 

Previously, we removed `-` to the `editor.nonWordCharacters` setting to allow words containing dashes to continue to be completed following https://github.com/atom/autocomplete-plus/pull/886. However, this changed cursor movement behavior. This PR reverts that change and *adds* `-` to `autocomplete.extraWordCharacters` to achieve the same effect. Depends on https://github.com/atom/autocomplete-plus/pull/944.